### PR TITLE
Windows port: login flow + launcher + tray + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A cross-platform Desktop YouTube Music client made with Libadwaita
 To run this application, you will need to install the following dependencies on your system:
 
 - **[uv](https://docs.astral.sh/uv/#installation)**: An extremely fast Python package installer and resolver.
-- **[GTK4 / libadwaita / GObject / GStreamer](https://www.gtk.org/docs/installations/)**: The GNOME UI libraries and their respective Python bindings.
+- **[GTK4 / libadwaita / GObject](https://www.gtk.org/docs/installations/)**: The GNOME UI libraries and their respective Python bindings.
 - **[NodeJS](https://nodejs.org/en/download/), [Bun](https://bun.sh/docs/installation), or [Deno](https://deno.land/manual/getting_started/installation)**: Required by `yt-dlp` to execute JavaScript for extracting certain streams.
 - **[mpv](https://mpv.io/)**: A free and open-source media player.
 

--- a/lib/sys/mpris.py
+++ b/lib/sys/mpris.py
@@ -59,7 +59,7 @@ def setup_mpris_controller(state: "PlayerState") -> None:
         if not state.current_item:
             return {}
         current = state.current_item
-        # MPRIS length expects microseconds. GStreamer yields nanoseconds.
+        # MPRIS length expects microseconds while the player state uses nanoseconds.
         length_us: int = state.stream.total_time.value // 1000
 
         metadata = {

--- a/lib/sys/win_gi.py
+++ b/lib/sys/win_gi.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def configure_windows_gi_runtime() -> list[Path]:
+    configured_roots: list[Path] = []
+    seen_roots: set[Path] = set()
+    candidate_roots = [
+        os.environ.get("GTK_ROOT"),
+        os.environ.get("GTK_DIR"),
+        r"C:\gtk",
+    ]
+
+    for candidate in candidate_roots:
+        if not candidate:
+            continue
+
+        root = Path(candidate).expanduser()
+        if root in seen_roots:
+            continue
+        seen_roots.add(root)
+
+        bin_dir = root / "bin"
+        typelib_dir = root / "lib" / "girepository-1.0"
+        if not (bin_dir.is_dir() and typelib_dir.is_dir()):
+            continue
+
+        os.add_dll_directory(str(bin_dir))
+        os.environ["PATH"] = f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"
+        os.environ["GI_TYPELIB_PATH"] = str(typelib_dir)
+
+        configured_roots.append(root)
+
+    return configured_roots

--- a/lib/sys/win_mpv.py
+++ b/lib/sys/win_mpv.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def configure_windows_mpv_runtime() -> list[Path]:
+    configured_dirs: list[Path] = []
+    seen_dirs: set[Path] = set()
+    candidate_dirs = [
+        os.environ.get("MPV_DLL_DIR"),
+        str(Path.home() / "scoop" / "apps" / "mpv" / "current"),
+        r"C:\msys64\ucrt64\bin",
+        r"C:\msys64\mingw64\bin",
+    ]
+
+    for candidate in candidate_dirs:
+        if not candidate:
+            continue
+
+        directory = Path(candidate).expanduser()
+        if directory in seen_dirs or not directory.is_dir():
+            continue
+        seen_dirs.add(directory)
+
+        if not any((directory / dll_name).is_file() for dll_name in ("mpv-2.dll", "libmpv-2.dll", "mpv-1.dll")):
+            continue
+
+        os.add_dll_directory(str(directory))
+        os.environ["PATH"] = f"{directory}{os.pathsep}{os.environ.get('PATH', '')}"
+        configured_dirs.append(directory)
+
+    return configured_dirs

--- a/lib/ui/play_bar.py
+++ b/lib/ui/play_bar.py
@@ -11,7 +11,7 @@ from lib.ui.helpers import toggle_icon
 from lib.ui.helpers import format_time
 from lib.state.player_state import PlayState
 from typing import Optional
-from gi.repository import Gtk, GLib, Adw, Pango, Gst, Gio, Gdk
+from gi.repository import Gtk, GLib, Adw, Pango, Gio, Gdk
 from reactivex import combine_latest
 from lib.state.player_state import PlayerState, play_next, play_previous
 
@@ -433,7 +433,7 @@ def PlayBar(
     show_now_playing: BehaviorSubject[bool],
 ) -> Gtk.Widget:
     """
-    A GStreamer-powered play bar built using functional components.
+    A play bar built using functional components.
     """
     # Main PlayBar vertical Box
     play_bar = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)

--- a/main.py
+++ b/main.py
@@ -10,19 +10,53 @@ def main():
     logging.basicConfig(
         level=logging.DEBUG, format="[%(levelname)s] %(name)s: %(message)s"
     )
+
     from lib.sys.mac_gi import mac_brew_fix
 
-    mac_brew_fix()
+    windows_gi_roots = []
+    windows_mpv_dirs = []
+    if sys.platform == "darwin":
+        mac_brew_fix()
+    elif sys.platform == "win32":
+        from lib.sys.win_gi import configure_windows_gi_runtime
+        from lib.sys.win_mpv import configure_windows_mpv_runtime
 
-    import gi
+        windows_gi_roots = configure_windows_gi_runtime()
+        windows_mpv_dirs = configure_windows_mpv_runtime()
 
-    gi.require_version("Gtk", "4.0")
-    gi.require_version("Adw", "1")
-    gi.require_version("Gst", "1.0")
-    gi.require_version("Pango", "1.0")
-    gi.require_version("Gio", "2.0")
-    gi.require_version("GdkPixbuf", "2.0")
-    gi.require_version("Gdk", "4.0")
+    try:
+        import gi
+    except ImportError as exc:
+        if sys.platform == "win32":
+            configured = ", ".join(str(path) for path in windows_gi_roots) or "none"
+            raise RuntimeError(
+                "PyGObject could not load on Windows. Install a GTK4 runtime "
+                "(for example under C:\\gtk with bin/ and lib\\girepository-1.0) "
+                f"and ensure it matches this Python architecture. Configured GTK roots: {configured}."
+            ) from exc
+        raise
+
+    required_namespaces = {
+        "Gtk": "4.0",
+        "Adw": "1",
+        "Pango": "1.0",
+        "Gio": "2.0",
+        "GdkPixbuf": "2.0",
+        "Gdk": "4.0",
+    }
+    try:
+        for namespace, version in required_namespaces.items():
+            gi.require_version(namespace, version)
+    except ValueError as exc:
+        if sys.platform == "win32":
+            configured = ", ".join(str(path) for path in windows_gi_roots) or "none"
+            missing_namespace = str(exc)
+            raise RuntimeError(
+                "A required GI namespace is missing from the Windows GTK runtime. "
+                "This app needs GTK4 and libadwaita typelibs installed. "
+                f"{missing_namespace}. Configured GTK roots: {configured}."
+            ) from exc
+        raise
 
     from gi.repository import GLib
 
@@ -46,7 +80,17 @@ def main():
     GLib.set_prgname(app_name)
     GLib.set_application_name(app_name)
 
-    from lib.ui.app import YTMusicApp
+    try:
+        from lib.ui.app import YTMusicApp
+    except OSError as exc:
+        if sys.platform == "win32" and "mpv" in str(exc).lower():
+            configured = ", ".join(str(path) for path in windows_mpv_dirs) or "none"
+            raise RuntimeError(
+                "libmpv could not be loaded on Windows. Install a build that includes "
+                "mpv-2.dll or libmpv-2.dll, or point MPV_DLL_DIR at that folder. "
+                f"Configured mpv directories: {configured}."
+            ) from exc
+        raise
 
     app = YTMusicApp(
         application_id=app_id,


### PR DESCRIPTION
Implemented a Windows-compatible workflow for this fork:

- Added Windows login flow with webview helper + fallback handling
- Added Windows launchers: win_ytmusic_launcher.vbs (normal), win_ytmusic_launcher_dev.cmd (debug)
- Improved tray/minimize behavior on Windows
- Updated playback/UI handling related to Windows behavior
- Added Windows setup guide: docs/windows-setup.md
- Updated README and .gitignore