### PR TITLE
🔒 Restrict permissions on sensitive session files

### DIFF
--- a/lib/net/api.py
+++ b/lib/net/api.py
@@ -44,6 +44,7 @@ def save_cookies(cookies_dict: dict):
     try:
         with open(COOKIE_CACHE, "w") as f:
             json.dump(cookies_dict, f)
+        os.chmod(COOKIE_CACHE, 0o600)
         logging.info(f"Cookies saved to {COOKIE_CACHE}")
     except Exception as e:
         logging.error(f"Failed to save cookies: {e}")
@@ -109,6 +110,7 @@ def auto_login(force_refresh: bool = False) -> Optional[ytmusicapi.YTMusic]:
     try:
         # Official setup call
         ytmusicapi.setup(filepath=BROWSER_JSON, headers_raw=raw_headers)
+        os.chmod(BROWSER_JSON, 0o600)
         yt = ytmusicapi.YTMusic(BROWSER_JSON)
 
         # Verify authentication


### PR DESCRIPTION
🎯 **What:** Fixed insecure storage of session cookies and browser configuration files.
⚠️ **Risk:** Sensitive authentication data was stored with default permissions, potentially allowing other users on the same system to gain unauthorized access to the user's account.
🛡️ **Solution:** Applied `os.chmod(..., 0o600)` to `cookies.json` and `browser.json` to ensure these files are only readable and writable by the owner.

---
*PR created automatically by Jules for task [3411611152723179832](https://jules.google.com/task/3411611152723179832) started by @yamada-sexta*